### PR TITLE
Create robots.txt file to avoid indexing

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## What I Did

Your fork of our old docs are configured to be hosted by github pages and so is published at https://github.com/b-gyula/liquibase-doc.

This is making google angry when it sees duplicate content between the main docs and this old copy.

This robots.txt file keeps google from indexing it if you are wanting to keep this old copy up. 

Alternatively, there is a setting in your forked repository to stop publishing it if you don't need the site published anymore.
