### PR TITLE
Add robots noindex/nofollow meta tag

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,6 +12,7 @@
     <title>Liquibase | {{ page.title }}</title>
     <meta name="description" content="{{ page.title }}">
     <meta content="width=device-width" name="viewport">
+    <meta name='robots' content='noindex,nofollow' />
 
     <link href="http://www.liquibase.org/rss.xml" rel="alternate" title="Liquibase RSS Feed" type="application/rss+xml"/>
 


### PR DESCRIPTION
## What I Did

Follow-up to https://github.com/b-gyula/liquibase-doc/pull/1 which tries a different approach to block indexing.

The first try didn't work because I forgot that it gets published as https://b-gyula.github.io/liquibase-doc/robots.txt and not https://b-gyula.github.io/robots.txt which is where google and friends need the robots.txt file to be.

This PR instead adds a meta tag to the base HTML template to tell these pages to not be indexed. That seemed to me like the easiest way to get them to not be indexed.